### PR TITLE
Add conversion of adminitions to raw HTML

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.3.1.0 by Daniel Nüst:
+
+ * Added admonition processing
+
 0.3.0.0 by Adam Twardoch:
 
  * Renamed project to 'mkdocs-combine'

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ extras:
   -l, --latex           combine the \( \) Markdown math into LaTeX $$ inlines
   -i IMAGE_EXT, --image-ext IMAGE_EXT
                         replace image extensions by (default: no replacement)
+  -d, --admonitions-md  convert admonitions to HTML already in the Markdown
 ```
 
 ## Usage example

--- a/mkdocs_combine/cli/mkdocscombine.py
+++ b/mkdocs_combine/cli/mkdocscombine.py
@@ -126,6 +126,8 @@ def parse_args():
 
     args_extras.add_argument('-i', '--image-ext', dest='image_ext', default=None,
                              help="replace image extensions by (default: no replacement)")
+    args_extras.add_argument('-d', '--admonitions-md', dest='convert_admonition_md', action='store_true',
+                             help='convert admonitions to HTML already in the Markdown')
 
     return args.parse_args()
 
@@ -148,6 +150,7 @@ def main():
             add_chapter_heads=args.add_chapter_heads,
             increase_heads=args.increase_heads,
             add_page_break=args.add_page_break,
+            convert_admonition_md=args.convert_admonition_md
         )
     except FatalError as e:
         print(e.message, file=sys.stderr)

--- a/mkdocs_combine/filters/admonitions.py
+++ b/mkdocs_combine/filters/admonitions.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+#
+# Copyright 2015 Johannes Grassler <johannes@btw23.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# mdtableconv.py - converts pipe tables to Pandoc's grid tables
+
+import markdown.extensions.admonition as adm
+import markdown.blockparser
+from markdown.util import etree
+
+class AdmonitionFilter(adm.AdmonitionProcessor):
+
+    def __init__(self, encoding='utf-8', tab_length = 4):
+        self.encoding = encoding
+        self.tab_length = tab_length
+
+    def blocks(self, lines):
+        """Groups lines into markdown blocks"""
+        state = markdown.blockparser.State()
+        blocks = []
+
+        # We use three states: start, ``` and '\n'
+        state.set('start')
+
+        # index of current block
+        currblock = 0
+
+        for line in lines:
+            line += '\n'
+            if state.isstate('start'):
+                if line[:3] == '```':
+                    state.set('```')
+                else:
+                    state.set('\n')
+                blocks.append('')
+                currblock = len(blocks) - 1
+            else:
+                marker = line[:3]  # Will capture either '\n' or '```'
+                if state.isstate(marker):
+                    state.reset()
+            blocks[currblock] += line
+
+        return blocks
+
+    def run(self, lines):
+        """Filter method: Passes all blocks through convert_admonition() and returns a list of lines."""
+        ret = []
+
+        blocks = self.blocks(lines)
+        for block in blocks:
+
+            ret.extend(self.convert_admonition(block))
+
+        return ret
+
+    def convert_admonition(self, block):
+        lines = block.split('\n')
+
+        if self.RE.search(block):
+
+            m = self.RE.search(lines.pop(0))
+            klass, title = self.get_class_and_title(m)
+            
+            lines = list(map(lambda x:self.detab(x)[0], lines))
+            lines = '\n'.join(lines[:-1])
+            
+            div = etree.Element('div')
+            div.set('class', '%s %s' % (self.CLASSNAME, klass))
+            if title:
+                p = etree.SubElement(div, 'p')
+                p.set('class', self.CLASSNAME_TITLE)
+                p.text = title
+
+            content = etree.SubElement(div, 'p')
+            content.text = lines
+
+            string = etree.tostring(div).decode(self.encoding)
+            lines = [string]
+            lines.append('')
+
+        return lines

--- a/mkdocs_combine/mkdocs_combiner.py
+++ b/mkdocs_combine/mkdocs_combiner.py
@@ -31,6 +31,7 @@ import mkdocs_combine.filters.metadata
 import mkdocs_combine.filters.tables
 import mkdocs_combine.filters.toc
 import mkdocs_combine.filters.xref
+import mkdocs_combine.filters.admonitions
 from mkdocs_combine.exceptions import FatalError
 
 
@@ -51,6 +52,7 @@ class MkDocsCombiner:
         self.add_chapter_heads = kwargs.get('add_chapter_heads', True)
         self.add_page_break = kwargs.get('add_page_break', False)
         self.increase_heads = kwargs.get('increase_heads', True)
+        self.convert_admonition_md = kwargs.get('convert_admonition_md', False)
         self.combined_md_lines = []
         self.html_bare = u''
         self.html = u''
@@ -209,6 +211,9 @@ class MkDocsCombiner:
         if self.filter_xrefs:
             lines = mkdocs_combine.filters.xref.XrefFilter().run(lines)
 
+        # Convert admonitions already for Markdown output
+        if self.convert_admonition_md:
+            lines = mkdocs_combine.filters.admonitions.AdmonitionFilter().run(lines)
         if self.filter_toc:
             lines = mkdocs_combine.filters.toc.TocFilter().run(lines)
 

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,7 @@ long_description = (
 setup(
     name='mkdocs-combine',
 
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.3.0.1',
+    version='0.3.1.0',
 
     description='Combines a MkDocs Markdown site into a single Markdown file',
 


### PR DESCRIPTION
I heavily use [markdown admonitions](https://pythonhosted.org/Markdown/extensions/admonition.html) in my mkdocs document, and this was the simplest way for me to integrate them, since downstream pandoc tools, in my case the filter https://github.com/chdemko/pandoc-latex-admonition, do not support them. This PR adds a filter to 

Let me know if you'd welcome this in the fork, if not, I'll maintain it in my own.

I also made some changes in version definition and (re?)added verbose logging, see https://github.com/twardoch/mkdocs-combine/compare/master...o2r-project:single-version-location?expand=1