### PR TITLE
Fixed title retrieval

### DIFF
--- a/mkdocs_combine/mkdocs_combiner.py
+++ b/mkdocs_combine/mkdocs_combiner.py
@@ -117,10 +117,11 @@ class MkDocsCombiner:
         for page in pages:
             if type(page) in str_type:
                 file_path = docs_dir / page
+                doc_title = mkdocs.utils.get_markdown_title(file_path.open('r').read())
                 flattened.append(
                     {
                         u'file' : page,
-                        u'title': u'%s {: .page-title}' % mkdocs.utils.get_markdown_title(file_path.open('r').read()),
+                        u'title': u'%s {: .page-title}' % doc_title,
                         u'level': level,
                     })
             if type(page) is list:

--- a/mkdocs_combine/mkdocs_combiner.py
+++ b/mkdocs_combine/mkdocs_combiner.py
@@ -15,6 +15,7 @@
 #
 import codecs
 import os
+from pathlib import Path
 import sys
 
 import markdown
@@ -114,10 +115,11 @@ class MkDocsCombiner:
 
         for page in pages:
             if type(page) in str_type:
+                file_path = Path(page)
                 flattened.append(
                     {
                         u'file' : page,
-                        u'title': u'%s {: .page-title}' % mkdocs.utils.filename_to_title(page),
+                        u'title': u'%s {: .page-title}' % mkdocs.utils.get_markdown_title(file_path.open('r').read()),
                         u'level': level,
                     })
             if type(page) is list:

--- a/mkdocs_combine/mkdocs_combiner.py
+++ b/mkdocs_combine/mkdocs_combiner.py
@@ -113,9 +113,10 @@ class MkDocsCombiner:
         else:
             str_type = (str, self.encoding)
 
+        docs_dir = Path(self.config['docs_dir'])
         for page in pages:
             if type(page) in str_type:
-                file_path = Path(page)
+                file_path = docs_dir / page
                 flattened.append(
                     {
                         u'file' : page,


### PR DESCRIPTION
# Why?

`mkdocs.utils.filename_to_title` member does not exist anymore.

# How?

Make use of `mkdocs.utils.get_markdown_title` instead.
