### PR TITLE
update for actual mkdocs version

### DIFF
--- a/mkdocs_combine/cli/mkdocscombine.py
+++ b/mkdocs_combine/cli/mkdocscombine.py
@@ -24,9 +24,17 @@ import sys
 
 import mkdocs_combine
 from mkdocs_combine.exceptions import FatalError
-from pkg_resources import get_distribution
 
-__version__ = get_distribution("mkdocs-combine").version
+# Use importlib.metadata for version retrieval (Python 3.8+), fallback to importlib_metadata for older versions
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("mkdocs-combine")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 
 def stdout_file(encoding):

--- a/mkdocs_combine/filters/admonitions.py
+++ b/mkdocs_combine/filters/admonitions.py
@@ -18,7 +18,7 @@
 
 import markdown.blockparser
 import markdown.extensions.admonition as adm
-from markdown.util import etree
+from xml.etree import ElementTree as etree
 
 
 class AdmonitionFilter(adm.AdmonitionProcessor):

--- a/py-requirements.txt
+++ b/py-requirements.txt
@@ -1,3 +1,3 @@
 Markdown>=3.0.1
-mkdocs>=1.0.4
+mkdocs>=1.6.1
 markdown-include>=0.5.1


### PR DESCRIPTION
resolve #21

- update mkdocs requirements
- replace filename_to_title function
- exclude external links from nav
- check for possible injections via filenames
- update version retrieval
- replace etree with xml.etree

## Summary by Sourcery

Adapt mkdocs-combine to modern mkdocs and Python environments by removing legacy code, enhancing security checks for file handling, updating versioning, and replacing deprecated imports.

Bug Fixes:
- Convert file-opening errors into warnings to skip unreadable files instead of raising fatal errors

Enhancements:
- Remove Python 2 compatibility branches and simplify string type logic in flatten_pages
- Replace mkdocs.utils.filename_to_title with the plugin’s own filename_to_title
- Add path traversal, existence, extension, and error handling checks when combining documentation files
- Switch CLI version detection to use importlib.metadata (with fallback to importlib_metadata)
- Replace deprecated markdown.util.etree import with xml.etree.ElementTree